### PR TITLE
chore(deps): group routine Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,27 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
+    # Collapse routine updates into one PR per ecosystem; majors stay
+    # individual so they can be reviewed on their own merits.
+    groups:
+      docker-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
+    # Collapse routine updates into one PR per ecosystem; majors stay
+    # individual so they can be reviewed on their own merits.
+    groups:
+      github-actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

No update stanza in this repo used `groups:`, so Dependabot opens one PR per dependency per week. Across the org that has accumulated **148 open Dependabot PRs**, the oldest from 2026-03-23 (Alteriom/alteriom-dev-ops#1987).

Grouping minor and patch updates collapses the routine ones into a single PR per ecosystem, and frees the `open-pull-requests-limit` slots they were silently consuming — several repos are at their limit and withholding newer updates as a result.

**Majors are deliberately left ungrouped.** 48 of the 148 open PRs are major bumps (eslint 9→10, typescript 5→6, vite 6→7, actions/checkout 4→6); batching those into a shared PR would make each one harder to review and one bad member would block the rest.

`open-pull-requests-limit` is left unchanged on purpose: grouping already frees slots, and raising the cap would surface *more* individual major PRs — the exact noise this is meant to reduce.

## Composes with the sweep

Alteriom/alteriom-dev-ops#1995 adds a scheduled org-wide sweep that approves and merges Dependabot PRs whose CI is green. It classifies a grouped PR by its **most severe member**, so:

- a group of minor + patch bumps merges automatically once CI is green;
- a group containing a major never auto-merges.

Grouping therefore reduces PR count and CI load without weakening that gate.

## Test plan

Config-only change. Validated as YAML, and each stanza's `groups:` key parses to the expected `update-types: [minor, patch]`. Dependabot re-evaluates on its next scheduled run: it closes the superseded individual PRs and opens the grouped replacements.

Refs Alteriom/alteriom-dev-ops#1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)