### PR TITLE
Add agent review governance: AGENTS.md, CLAUDE.md, CI review-round cap (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,13 +325,52 @@ jobs:
   #     - name: Perform CodeQL Analysis
   #       uses: github/codeql-action/analyze@v3
 
+  # Review-loop governor — caps bot review rounds per PR (AGENTS.md § Review
+  # round budget). The budget mirrors MAX_REVIEW_ITERATIONS = 3 in the
+  # Command Center's pr_review_handler.py; change both together or neither.
+  # Past the budget this fails until a human review approves the PR, so the
+  # terminal state is a human decision instead of a 39th bot round (PR #59).
+  review-budget:
+    name: Review round budget
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Count bot review rounds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          MAX_REVIEW_ROUNDS: 3
+        run: |
+          rounds=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.body | test("^\\s*@codex review"; "i"))] | length')
+          echo "Bot review rounds requested on #$PR: $rounds (budget: $MAX_REVIEW_ROUNDS)"
+          if [ "$rounds" -le "$MAX_REVIEW_ROUNDS" ]; then
+            echo "Within budget."
+            exit 0
+          fi
+          approvals=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+            --jq '[.[] | select(.state == "APPROVED")] | length')
+          if [ "$approvals" -gt 0 ]; then
+            echo "Budget exceeded, but a human review has approved this PR — passing."
+            exit 0
+          fi
+          echo "::error::Review round budget exhausted ($rounds/$MAX_REVIEW_ROUNDS)."
+          echo "Do NOT post another '@codex review'. Post a summary of the open"
+          echo "threads and hand the PR to a human approver; once a human review"
+          echo "approves, re-run this check and it will pass."
+          exit 1
+
   # All checks passed
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, build-docker, test]
+    needs: [lint, build-docker, test, review-budget]
     if: always()
-    
+
     steps:
       - name: Check all jobs
         run: |
@@ -339,6 +378,12 @@ jobs:
              [[ "${{ needs.build-docker.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "One or more CI jobs failed"
+            exit 1
+          fi
+          # review-budget is skipped on push events; only a real failure gates.
+          if [[ "${{ needs.review-budget.result }}" != "success" ]] && \
+             [[ "${{ needs.review-budget.result }}" != "skipped" ]]; then
+            echo "Review round budget exhausted — hand this PR to a human approver (see AGENTS.md)."
             exit 1
           fi
           echo "All CI jobs passed successfully!"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Build directories
-build/
-build-*/
+build*/
 cmake-build-*/
 out/
 bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — painlessMesh-simulator
+
+Desktop simulator for the painlessMesh ESP32/ESP8266 mesh library (C++17,
+CMake, Boost.Asio). This file is the contract for **automated reviewers**
+(Codex, Copilot, Claude) and for agents responding to their findings. Author
+workflow rules live in `CLAUDE.md`; C++ style lives in
+`.github/copilot-instructions.md`.
+
+## Review scope
+
+- Judge the PR **against its linked issue** — the issue number in the PR
+  title/body defines what "done" means. Do not restate the scope here in
+  prose; the issue is the anchor and stays authoritative as scope evolves.
+- Work the PR does not need in order to close its issue is **out of scope
+  for review findings**. If a missing capability genuinely matters, say so
+  in a non-blocking comment and let a maintainer file a follow-up issue —
+  do not request the feature as a review finding. (Context: PR #59 grew
+  from 1,315 inserted lines to 11,263 — ~88% reviewer-generated scope —
+  including an 806-line solver no issue asked for.)
+- **Do flag** generated or build output in the diff. `build*/`, `bin/`,
+  `out/` must never be tracked (2,770 lines of generated Makefile went
+  unflagged through 38 review rounds on PR #59).
+
+## Severity floor
+
+- **P0/P1** — a defect with a concrete failing scenario (wrong output,
+  crash, data loss, security). These block merge and deserve a thread.
+- **P2 and below without a demonstrated failing scenario** — do not block
+  the PR. State it once; the author converts it to a follow-up issue and
+  resolves the thread. A P2 backlog on the PR is not a merge gate.
+
+## No fresh-evidence ratchet
+
+Do not raise a new finding against code that only exists because of your
+own previous round's finding ("fresh evidence after the previous fix").
+One round of review on a fix is part of the round that requested it; if
+the fix itself spawns a genuinely new defect, file it as an issue rather
+than extending the loop. On PR #59, 24 of 72 findings were this ratchet.
+
+## Review round budget
+
+**3 bot-review rounds per PR.** This mirrors `MAX_REVIEW_ITERATIONS = 3`
+in the Alteriom Command Center (`backend/src/claude_workflows/
+pr_review_handler.py`) — one number governs both review pathways; change
+them together or not at all. The budget is enforced mechanically by the
+`Review round budget` step of the required **CI Success** check, which
+counts `@codex review` requests on the PR. Past the budget the check
+fails until a human review approves the PR; the terminal state is a
+human decision, not a fourth round.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — painlessMesh-simulator
+
+Desktop simulator for painlessMesh (Alteriom fork, v2.0.0). C++17 + CMake +
+Ninja, Boost.Asio networking, yaml-cpp scenario configs. Reviewer contract
+(scope, severity floor, round budget) is in `AGENTS.md` — read it before
+requesting or answering a code review.
+
+## Key directories
+
+- `src/core/` — simulation engine (node lifecycle, event scheduler)
+- `src/network/` — virtual network layer over Boost.Asio
+- `src/config/` — YAML scenario/topology loading and validation
+- `src/firmware/` — firmware-behaviour emulation hooks
+- `src/cli/`, `src/main.cpp` — entry point
+- `test/` — Catch2 unit + integration tests (`test_*.cpp`)
+- `external/` — painlessMesh checkout (path via `-DPAINLESSMESH_PATH`)
+
+## Build
+
+```bash
+mkdir -p build && cd build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DPAINLESSMESH_PATH=<path> ..
+ninja && ctest
+```
+
+Never commit build output — `build*/`, `bin/`, `out/` are ignored; if
+`git status` shows a Makefile or object files, the build dir is
+misnamed, not an exception.
+
+## Review loop discipline
+
+Hard-learned on PR #59 (38 review rounds, 26 hours, 43 `@codex review`
+comments, diff grew 1,315 → 11,263 lines). The rules:
+
+- **Round budget: 3 `@codex review` requests per PR, total** — across all
+  agents and sessions, not per-agent. The count is enforced by the
+  `Review round budget` step in the required CI Success check and mirrors
+  the Command Center's `MAX_REVIEW_ITERATIONS = 3`.
+- **REVIEW_REQUIRED is a terminal state for agents.** When CI is green and
+  the PR is blocked only on a required human review: stop. Post one
+  summary comment (open threads, what was fixed, what was deferred) and
+  hand to a human approver. Do not request another bot review, do not
+  keep polling, do not merge.
+- **P2 findings without a failing scenario become follow-up issues**, not
+  fix commits on the PR. File the issue, link it in the thread, resolve
+  the thread.
+- **Scope stays anchored to the PR's linked issue.** A reviewer suggestion
+  that adds capability gets its own issue — implementing it mid-PR is how
+  a port becomes 11k lines.
+- **Review findings are recorded as GitHub issues**, not appended to
+  `docs/V2_RELEASE_REVIEW.md` or any other in-repo ledger.


### PR DESCRIPTION
## Summary

Closes #60.

PR #59's review loop ran **38 rounds over 26 hours** (43 `@codex review` comments, 208 comment objects, 63 P2 / 0 P0 findings) and only stopped on Codex quota errors. The diff grew from 1,315 inserted lines (the port) to 11,263 (~88% reviewer-generated scope), while 2,770 lines of committed build output went unflagged. Root cause: neither reader had a contract — no root `AGENTS.md` for the reviewer, no `CLAUDE.md` for the author-agent, and the Command Center's `MAX_REVIEW_ITERATIONS = 3` (`pr_review_handler.py`) never reaches the GitHub-native Codex path.

## Changes

- **`AGENTS.md`** (read by Codex): review scope anchored to the PR's linked issue (no prose scope list to go stale); severity floor — P0/P1 with a failing scenario block merge, P2 without one becomes a follow-up issue; explicit ban on raising findings against the previous round's own fix (24 of 72 findings on #59 were this ratchet); documents the round budget.
- **`CLAUDE.md`** (read by author agents): repo quick-reference plus review-loop discipline — 3 `@codex review` rounds per PR total, and `REVIEW_REQUIRED` as a terminal state: stop, post one summary, hand to a human approver. Findings are recorded as GitHub issues, not appended to `docs/V2_RELEASE_REVIEW.md`.
- **`ci.yml`**: new `Review round budget` job counts `@codex review` comments on the PR and fails past 3 — unless a human review has already approved, so the terminal is a human decision, not an unmergeable PR. Wired into the required **CI Success** gate so the cap is mechanical rather than prose (the high-severity risk on #60). Skipped on push events; `skipped` is treated as pass.
- **`.gitignore`**: `build/` + `build-*/` → `build*/` — `build2/` and `build_drift/` matched neither pattern, which is how 2,770 lines of generated Makefile got tracked on #59 without any of 38 review rounds noticing.

The budget value 3 deliberately mirrors `MAX_REVIEW_ITERATIONS = 3` in the Command Center so both review pathways share one number; both files say to change them together or neither.

## Testing

- `js-yaml` parse of `ci.yml` passes.
- `git check-ignore` confirms `build*/` now covers `build/`, `build2/`, `build_drift/`; no tracked paths on `main` match the widened pattern.
- The governor's jq/gh logic mirrors commands verified against PR #59 live data (43 matching comments → would fail; approval lift verified by reviews-endpoint query shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)