### PR TITLE
Keep validating supported events past an unmodelled action (#63)

### DIFF
--- a/include/simulator/topology_planner.hpp
+++ b/include/simulator/topology_planner.hpp
@@ -118,6 +118,14 @@ std::string topologyTypeName(TopologyType type);
  * - an `inject_message` whose sender is stopped at that point in the timeline
  *   (matches the runtime "injection refused" throw).
  *
+ * An action the walker has no lifecycle model for -- an unrecognised one, or
+ * `add_nodes` / `remove_node`, which move the node set -- does not abandon the
+ * timeline. It marks the state it could have changed as unknown, and only the
+ * checks reading that state are suspended; steps before it, and any node or
+ * link a later event names outright, are still judged. So a scenario carrying
+ * an unimplemented action still gets its supported events validated, while a
+ * component count that would have to be guessed is never reported.
+ *
  * @param events The scenario's events (declaration order; equal times keep it)
  * @param wiredLinks The links planTopology() will actually wire (its `links`)
  * @param nodes The scenario's nodes, for id resolution and the full node set

--- a/src/config/topology_planner.cpp
+++ b/src/config/topology_planner.cpp
@@ -642,18 +642,6 @@ std::vector<std::string> validateEventTimeline(
     const std::vector<NodeConfigExtended>& nodes) {
   std::vector<std::string> problems;
 
-  // If the timeline contains an action whose lifecycle effect this walker does
-  // not model, its running-state view would be unreliable and could flag a
-  // false positive. Skip rather than guess: an UNKNOWN action already fails
-  // validation on its own, and add/remove change the node set out from under us.
-  for (const auto& e : events) {
-    if (e.action == EventAction::UNKNOWN ||
-        e.action == EventAction::ADD_NODES ||
-        e.action == EventAction::REMOVE_NODE) {
-      return problems;
-    }
-  }
-
   auto key = [](uint32_t a, uint32_t b) {
     return a < b ? std::make_pair(a, b) : std::make_pair(b, a);
   };
@@ -676,6 +664,19 @@ std::vector<std::string> validateEventTimeline(
   std::set<uint32_t> running = allNodes;
   std::set<std::pair<uint32_t, uint32_t>> dropped;      // connection_drop / break_link
   std::set<std::pair<uint32_t, uint32_t>> partitionCut; // active partition, until heal
+
+  // An action whose lifecycle effect this walker does not model (UNKNOWN, or
+  // add/remove, which move the node set) makes the state it could have touched
+  // unreliable. The walker used to give up on the whole timeline the moment one
+  // appeared anywhere in the list, which discarded the deterministic failures
+  // among the supported events too -- including steps that ran *before* it with
+  // fully known state. Instead, mark what such a step could have changed as
+  // unknown and keep walking: a check is suppressed only while the state it
+  // reads is unknown, and a later event naming a node or link outright makes
+  // that piece known again. (issue 63)
+  std::set<uint32_t> unknownNodes;
+  std::set<std::pair<uint32_t, uint32_t>> unknownEdges;
+  bool unknownNodeSet = false;
 
   auto edgeLive = [&](uint32_t a, uint32_t b) {
     const auto k = key(a, b);
@@ -734,15 +735,22 @@ std::vector<std::string> validateEventTimeline(
     switch (e.action) {
       case EventAction::STOP_NODE:
       case EventAction::CRASH_NODE:
-        if (resolveId(nodes, e.target, a)) running.erase(a);
+        if (resolveId(nodes, e.target, a)) {
+          running.erase(a);
+          unknownNodes.erase(a);  // this event settles the node's state
+        }
         break;
       case EventAction::START_NODE:
-        if (resolveId(nodes, e.target, a)) running.insert(a);
+        if (resolveId(nodes, e.target, a)) {
+          running.insert(a);
+          unknownNodes.erase(a);
+        }
         break;
       case EventAction::RESTART_NODE:
         if (resolveId(nodes, e.target, a)) {
           if (step.isDelayedStart) running.insert(a);   // start half
           else running.erase(a);                        // stop half
+          unknownNodes.erase(a);
         }
         break;
       case EventAction::CONNECTION_DROP:
@@ -750,7 +758,10 @@ std::vector<std::string> validateEventTimeline(
         uint32_t x = 0, y = 0;
         const std::string& s = e.targets.size() >= 2 ? e.targets[0] : e.from;
         const std::string& t = e.targets.size() >= 2 ? e.targets[1] : e.to;
-        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) dropped.insert(key(x, y));
+        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) {
+          dropped.insert(key(x, y));
+          unknownEdges.erase(key(x, y));
+        }
         break;
       }
       case EventAction::CONNECTION_RESTORE:
@@ -758,7 +769,10 @@ std::vector<std::string> validateEventTimeline(
         uint32_t x = 0, y = 0;
         const std::string& s = e.targets.size() >= 2 ? e.targets[0] : e.from;
         const std::string& t = e.targets.size() >= 2 ? e.targets[1] : e.to;
-        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) dropped.erase(key(x, y));
+        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) {
+          dropped.erase(key(x, y));
+          unknownEdges.erase(key(x, y));
+        }
         break;
       }
       case EventAction::PARTITION_NETWORK: {
@@ -770,10 +784,20 @@ std::vector<std::string> validateEventTimeline(
           for (size_t j = i + 1; j < groups.size(); ++j) {
             for (uint32_t x : groups[i])
               for (uint32_t y : groups[j])
-                if (declared.count(key(x, y))) partitionCut.insert(key(x, y));
+                if (declared.count(key(x, y))) {
+                  partitionCut.insert(key(x, y));
+                  unknownEdges.erase(key(x, y));  // this cut settles the edge
+                }
           }
         }
-        if (topologyWired && componentCount() != groups.size()) {
+        // componentCount() reads the whole graph, so it is only meaningful when
+        // every node's running state, every declared edge and the node set
+        // itself are known. An earlier unmodelled step leaves at least one of
+        // those open, and a component count guessed from it would fail a
+        // scenario that is merely not implemented yet.
+        const bool stateKnown = !unknownNodeSet && unknownNodes.empty() &&
+                                unknownEdges.empty();
+        if (topologyWired && stateKnown && componentCount() != groups.size()) {
           problems.push_back(
               "network_partition " + describe(e) + " requests " +
               std::to_string(groups.size()) +
@@ -787,8 +811,22 @@ std::vector<std::string> validateEventTimeline(
       case EventAction::HEAL_PARTITION:
         partitionCut.clear();
         break;
+      case EventAction::UNKNOWN:
+      case EventAction::ADD_NODES:
+      case EventAction::REMOVE_NODE:
+        // No lifecycle model exists for these. An UNKNOWN action is an
+        // arbitrary string -- it could start, stop or relink anything -- and
+        // add/remove change the node set. Treat every node and declared edge as
+        // unknown from here on rather than guessing, and keep walking so the
+        // remaining supported events are still checked against whatever the
+        // timeline settles afterwards.
+        unknownNodes = allNodes;
+        unknownEdges = declared;
+        unknownNodeSet = true;
+        break;
       case EventAction::INJECT_MESSAGE:
-        if (resolveId(nodes, e.from, a) && !running.count(a)) {
+        if (resolveId(nodes, e.from, a) && !unknownNodes.count(a) &&
+            !running.count(a)) {
           problems.push_back(
               "inject_message " + describe(e) + " sends from node '" + e.from +
               "', which is stopped at that point in the timeline; the runtime "

--- a/test/test_topology_planner.cpp
+++ b/test/test_topology_planner.cpp
@@ -629,9 +629,10 @@ TEST_CASE("validateEventTimeline rejects sequences that must fail at runtime",
     REQUIRE(problems.empty());
   }
 
-  SECTION("an unmodelled action skips the check rather than guess") {
-    // start_all_nodes parses as UNKNOWN; the walker cannot track it, so it must
-    // not flag a false positive (the unknown action fails validation on its own).
+  SECTION("an unmodelled action suspends the checks that depend on it") {
+    // start_all_nodes parses as UNKNOWN; it could have restarted n2, so the
+    // component count the partition needs is no longer knowable and must not
+    // be guessed at (the unknown action fails validation on its own).
     EventConfig unknown; unknown.time = 6; unknown.action = EventAction::UNKNOWN;
     unknown.action_raw = "start_all_nodes";
     EventConfig part; part.time = 10; part.action = EventAction::PARTITION_NETWORK;
@@ -639,5 +640,62 @@ TEST_CASE("validateEventTimeline rejects sequences that must fail at runtime",
     const auto problems =
         validateEventTimeline({stopEvent(5, "n2"), unknown, part}, line, nodes);
     REQUIRE(problems.empty());
+  }
+
+  SECTION("a broken step before an unmodelled action is still reported") {
+    // The walker used to scan the whole list up front and return on any
+    // unmodelled action, discarding even the steps that ran before it with
+    // fully known state. Those are deterministic failures and must survive.
+    // (issue 63)
+    EventConfig inj; inj.time = 10; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    EventConfig unknown; unknown.time = 100; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    const auto problems =
+        validateEventTimeline({stopEvent(5, "n1"), inj, unknown}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
+  }
+
+  SECTION("an explicit event after an unmodelled one makes its target known again") {
+    // start_all_nodes leaves every node's running state unknown, but the later
+    // stop_node names n1 outright, so the injection after it is once again a
+    // certain failure.
+    EventConfig unknown; unknown.time = 5; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    EventConfig inj; inj.time = 20; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems =
+        validateEventTimeline({unknown, stopEvent(10, "n1"), inj}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
+  }
+
+  SECTION("an unmodelled action clears a stop the walker had recorded") {
+    // The mirror image: start_all_nodes may have brought n1 back, so the walker
+    // must not claim the later injection fails.
+    EventConfig unknown; unknown.time = 10; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    EventConfig inj; inj.time = 20; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems =
+        validateEventTimeline({stopEvent(5, "n1"), unknown, inj}, line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("add_nodes suspends the component count but not the injection check") {
+    // add_nodes changes the node set out from under componentCount(), so the
+    // partition -- which a prior stop_node would otherwise break -- is not
+    // judged. An injection from a node an explicit stop_node named afterwards
+    // still is, so exactly one problem comes back rather than none or two.
+    EventConfig add; add.time = 10; add.action = EventAction::ADD_NODES;
+    EventConfig part; part.time = 30; part.action = EventAction::PARTITION_NETWORK;
+    part.groups = {{"n1", "n2"}, {"n3"}};  // n2 is down: 3 components, not 2
+    EventConfig inj; inj.time = 40; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems = validateEventTimeline(
+        {stopEvent(5, "n2"), add, part, stopEvent(35, "n1"), inj}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
   }
 }


### PR DESCRIPTION
Closes #63.

## Stacking — please read first

`validateEventTimeline()` exists only on `feat/v2-release-readiness-58` (PR #59); it is not on `main`. So this PR is **based on that branch, not `main`**.

**Merge order matters:** this must land into `feat/v2-release-readiness-58` *before* #59 merges to `main`. If #59 merges first, GitHub closes this PR and the fix does not reach `main`. The alternative, if you prefer, is to cherry-pick `b06d8f6` straight onto #59's branch and close this.

It is kept off #59 deliberately: `AGENTS.md` § Severity floor says a P2 without a demonstrated failing scenario becomes a follow-up issue rather than more scope on #59, and #59 is already +8,494/−687.

## The defect

`validateEventTimeline()` pre-scanned the entire event list and returned an empty problem set if *any* action had no lifecycle model — `UNKNOWN`, or `add_nodes`/`remove_node`, which move the node set:

```cpp
for (const auto& e : events) {
  if (e.action == EventAction::UNKNOWN || ... ) {
    return problems;   // whole timeline discarded
  }
}
```

Because it was a whole-list pre-pass rather than a stop-at-first-unknown, one unmodelled step *anywhere* discarded every check — including steps scheduled **before** it, whose state is fully known and whose diagnostics were never at risk.

That interacts badly with `scripts/ci_integration_check.sh`. Its allowlist skips a scenario only when *every* reported error line is the expected unknown action or the generic "action not implemented". With the validator silent, a stopped-sender injection or lifecycle-broken partition in the same file never produced a line, so the gate read the scenario as a clean "not implemented yet" skip.

## The fix

The bail-out's stated reason — an arbitrary unrecognised action could start, stop or relink anything, so state after it is not knowable — is correct. Discarding the whole timeline is the wrong lever for it.

The walker now models an unmodelled step as *unknown effect*: it marks every node and declared edge unknown and keeps walking. Each check is suppressed only while the state it actually reads is unknown, and state a later event re-establishes becomes trustworthy again — an explicit `stop_node`/`start_node`/`restart_node` settles that node; a connection drop, restore or partition cut settles that edge.

Two classes of failure become visible again, with no new false positives:

- everything before the unmodelled step is judged exactly as before;
- an injection from a sender an explicit `stop_node` named *after* the unknown action is reported again.

The component count stays conservative: it reads the whole graph, so it is only reported when every node state, every declared edge and the node set itself are known. After an unmodelled step at least one is open, so a partition is **not judged rather than guessed at**.

## Effect on the allowlisted scenarios

Deliberately none — they keep skipping on their expected action alone:

| scenario | timeline | outcome |
|---|---|---|
| `network_partition_test.yaml` | `start_all_nodes` **t=0**, partition t=30, heal t=60 | unknown action is first, so the partition is not judged — unchanged |
| `split_brain_partition_test.yaml` | `start_all_nodes` **t=0**, partition t=30, heal t=90 | same |
| `issue_138_cascade_healing.yaml` | partition t=30, `partial_heal` t=70, heal t=120 | the t=30 partition is **now checked** (state fully known); all three groups are internally connected in the `mesh` plan — `planTopology()`'s `infeasible_partitions` already asserts this and is empty — so it passes |

## Tests

`test/test_topology_planner.cpp`, in the existing `validateEventTimeline` case. The prior "unmodelled action" section is kept (a partition after `start_all_nodes` must still not be flagged), plus four new sections:

- a broken step **before** the unmodelled action is still reported;
- state an explicit event re-establishes after an unmodelled one is trusted again;
- the mirror case — the unknown action may have undone a recorded stop, so nothing is reported;
- `add_nodes` suspends the component count while the injection check survives (exactly one problem, not none or two).

## Verification

**Not built or run locally** — this container has no C++ toolchain (no compiler, no root, no Docker), so I could not compile. CI is the real verification here.

Note the branch is named `feature/…` on purpose: `ci.yml` fires `pull_request` only for `main`/`develop` and `push` only for `master, main, develop, feature/**`. A PR stacked on `feat/v2-release-readiness-58` from any other prefix gets **zero checks** (that was #64, closed). The `feature/**` push trigger attaches real check runs to this commit, so the build, Catch2 suite and `ci_integration_check.sh` results below are genuine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
