### PR TITLE
Check injection reachability after topology changes (#62)

### DIFF
--- a/examples/scenarios/ISSUE_138_SCENARIOS.md
+++ b/examples/scenarios/ISSUE_138_SCENARIOS.md
@@ -48,8 +48,8 @@ Issue #138 likely relates to split-brain scenarios in mesh networks where:
 **Purpose**: Explicitly tests message delivery before, during, and after partition
 
 **Key Features**:
-- Injects test messages at each phase
-- Validates intra-partition vs cross-partition routing
+- Injects test messages before, during and after the partition
+- Validates intra-partition routing while the mesh is split
 - Tests message delivery across previously partitioned groups
 - Comprehensive routing validation
 
@@ -65,8 +65,12 @@ Issue #138 likely relates to split-brain scenarios in mesh networks where:
 **Expected Results**:
 - ✓ 100% delivery rate in unified mesh (phase 1 and 6)
 - ✓ Intra-partition messages succeed during partition
-- ✓ Cross-partition messages properly blocked during partition
 - ✓ All cross-partition messages work after healing
+
+A cross-partition probe is deliberately *not* injected while the mesh is split:
+a refused injection throws out of `MessageInjectEvent` and aborts the run, so it
+would take phases 5 and 6 -- the ones that actually test issue #138 -- with it.
+`partition_delivery_test.yaml` measures isolation by delivery counts instead.
 
 **Failure Indicators**:
 - ✗ Messages fail between previously partitioned nodes after healing

--- a/examples/scenarios/issue_138_message_routing.yaml
+++ b/examples/scenarios/issue_138_message_routing.yaml
@@ -127,23 +127,20 @@ events:
     payload: '{"test": "phase3-broadcast-p2", "from": "node-5", "phase": "partition"}'
     description: "Phase 3: Test broadcast within partition 2"
   
-  # === Phase 4: Test cross-partition messaging (should fail) (60-70s) ===
-  
-  # Message from partition 1 to partition 2 (should fail/drop)
-  - time: 60
-    action: inject_message
-    from: "node-1"
-    to: "node-6"
-    payload: '{"test": "phase4-cross-p1-to-p2", "from": "node-1", "to": "node-6", "phase": "partition"}'
-    description: "Phase 4: Test cross-partition message (should fail)"
-  
-  # Message from partition 2 to partition 1 (should fail/drop)
-  - time: 65
-    action: inject_message
-    from: "node-6"
-    to: "node-1"
-    payload: '{"test": "phase4-cross-p2-to-p1", "from": "node-6", "to": "node-1", "phase": "partition"}'
-    description: "Phase 4: Test reverse cross-partition message (should fail)"
+  # === Phase 4: Cross-partition messaging — deliberately absent ===
+  #
+  # This phase used to inject node-1 -> node-6 and node-6 -> node-1 while the
+  # partition was up, annotated "should fail/drop". It cannot be expressed that
+  # way: inject_message has no "expected to be refused" form. sendSingle() finds
+  # no route across the cut, VirtualNode::injectMessage() returns false, and
+  # MessageInjectEvent throws -- so the run aborted at t=60 and phases 5 and 6,
+  # the ones that actually test issue #138's post-heal routing, never ran.
+  #
+  # validateEventTimeline() now rejects an injection whose destination earlier
+  # events put out of reach, so the scenario would fail --validate-only too.
+  # Partition isolation is asserted instead by partition_delivery_test.yaml,
+  # which compares delivery counts against a control run rather than asking a
+  # single probe to fail.
   
   # === Phase 5: Heal partition (90s) ===
   
@@ -237,11 +234,9 @@ metrics:
 #   - time=55: Broadcast from node-5 → reaches node-4,5,6 only ✓
 #   - message_delivery_rate = 100% within partitions
 #
-# Phase 4 (60-70s): Cross-partition - MUST FAIL
-#   - time=60: node-1 → node-6 (P1 to P2) → DROPPED ✗
-#   - time=65: node-6 → node-1 (P2 to P1) → DROPPED ✗
-#   - dropped_message_count = 2
-#   - This validates partition isolation
+# Phase 4: not injected here -- see the note in the events list. A refused
+#   injection aborts the run, so partition isolation is measured by
+#   partition_delivery_test.yaml's control-vs-split delivery counts instead.
 #
 # Phase 6 (100-145s): After healing - ALL MESSAGES SUCCEED AGAIN
 #   - time=100: node-1 → node-6 → SUCCESS ✓ CRITICAL!

--- a/include/simulator/topology_planner.hpp
+++ b/include/simulator/topology_planner.hpp
@@ -118,6 +118,14 @@ std::string topologyTypeName(TopologyType type);
  * - an `inject_message` whose sender is stopped at that point in the timeline
  *   (matches the runtime "injection refused" throw).
  *
+ * An action the walker has no lifecycle model for -- an unrecognised one, or
+ * `add_nodes` / `remove_node`, which move the node set -- does not abandon the
+ * timeline. It marks the state it could have changed as unknown, and only the
+ * checks reading that state are suspended; steps before it, and any node or
+ * link a later event names outright, are still judged. So a scenario carrying
+ * an unimplemented action still gets its supported events validated, while a
+ * component count that would have to be guessed is never reported.
+ *
  * @param events The scenario's events (declaration order; equal times keep it)
  * @param wiredLinks The links planTopology() will actually wire (its `links`)
  * @param nodes The scenario's nodes, for id resolution and the full node set

--- a/include/simulator/topology_planner.hpp
+++ b/include/simulator/topology_planner.hpp
@@ -109,14 +109,19 @@ std::string topologyTypeName(TopologyType type);
  * breaks because of an *earlier* event slips through `--validate-only` and only
  * fails once the run is underway. This walks the events in scheduled order,
  * tracking each node's up/down state (and connection drops / partition cuts),
- * and reports the two deterministic mismatches:
+ * and reports the deterministic mismatches:
  *
  * - a `network_partition` whose groups no longer form exactly that many
  *   connected components in the live mesh -- e.g. a prior `stop_node` split a
  *   group by taking down its articulation node (matches the runtime throw in
  *   NetworkPartitionEvent);
  * - an `inject_message` whose sender is stopped at that point in the timeline
- *   (matches the runtime "injection refused" throw).
+ *   (matches the runtime "injection refused" throw);
+ * - an `inject_message` whose destination those same events have put out of
+ *   reach of the sender, or -- for a broadcast -- that leave the sender with
+ *   no live peer to hand a first hop to. Both make the runtime's send return
+ *   false, which MessageInjectEvent turns into a throw, so the run exits 1
+ *   however healthy the sender itself is.
  *
  * An action the walker has no lifecycle model for -- an unrecognised one, or
  * `add_nodes` / `remove_node`, which move the node set -- does not abandon the
@@ -124,7 +129,8 @@ std::string topologyTypeName(TopologyType type);
  * checks reading that state are suspended; steps before it, and any node or
  * link a later event names outright, are still judged. So a scenario carrying
  * an unimplemented action still gets its supported events validated, while a
- * component count that would have to be guessed is never reported.
+ * component count or a reachability verdict that would have to be guessed is
+ * never reported.
  *
  * @param events The scenario's events (declaration order; equal times keep it)
  * @param wiredLinks The links planTopology() will actually wire (its `links`)

--- a/src/config/topology_planner.cpp
+++ b/src/config/topology_planner.cpp
@@ -642,18 +642,6 @@ std::vector<std::string> validateEventTimeline(
     const std::vector<NodeConfigExtended>& nodes) {
   std::vector<std::string> problems;
 
-  // If the timeline contains an action whose lifecycle effect this walker does
-  // not model, its running-state view would be unreliable and could flag a
-  // false positive. Skip rather than guess: an UNKNOWN action already fails
-  // validation on its own, and add/remove change the node set out from under us.
-  for (const auto& e : events) {
-    if (e.action == EventAction::UNKNOWN ||
-        e.action == EventAction::ADD_NODES ||
-        e.action == EventAction::REMOVE_NODE) {
-      return problems;
-    }
-  }
-
   auto key = [](uint32_t a, uint32_t b) {
     return a < b ? std::make_pair(a, b) : std::make_pair(b, a);
   };
@@ -676,6 +664,19 @@ std::vector<std::string> validateEventTimeline(
   std::set<uint32_t> running = allNodes;
   std::set<std::pair<uint32_t, uint32_t>> dropped;      // connection_drop / break_link
   std::set<std::pair<uint32_t, uint32_t>> partitionCut; // active partition, until heal
+
+  // An action whose lifecycle effect this walker does not model (UNKNOWN, or
+  // add/remove, which move the node set) makes the state it could have touched
+  // unreliable. The walker used to give up on the whole timeline the moment one
+  // appeared anywhere in the list, which discarded the deterministic failures
+  // among the supported events too -- including steps that ran *before* it with
+  // fully known state. Instead, mark what such a step could have changed as
+  // unknown and keep walking: a check is suppressed only while the state it
+  // reads is unknown, and a later event naming a node or link outright makes
+  // that piece known again. (issue 63)
+  std::set<uint32_t> unknownNodes;
+  std::set<std::pair<uint32_t, uint32_t>> unknownEdges;
+  bool unknownNodeSet = false;
 
   auto edgeLive = [&](uint32_t a, uint32_t b) {
     const auto k = key(a, b);
@@ -734,15 +735,22 @@ std::vector<std::string> validateEventTimeline(
     switch (e.action) {
       case EventAction::STOP_NODE:
       case EventAction::CRASH_NODE:
-        if (resolveId(nodes, e.target, a)) running.erase(a);
+        if (resolveId(nodes, e.target, a)) {
+          running.erase(a);
+          unknownNodes.erase(a);  // this event settles the node's state
+        }
         break;
       case EventAction::START_NODE:
-        if (resolveId(nodes, e.target, a)) running.insert(a);
+        if (resolveId(nodes, e.target, a)) {
+          running.insert(a);
+          unknownNodes.erase(a);
+        }
         break;
       case EventAction::RESTART_NODE:
         if (resolveId(nodes, e.target, a)) {
           if (step.isDelayedStart) running.insert(a);   // start half
           else running.erase(a);                        // stop half
+          unknownNodes.erase(a);
         }
         break;
       case EventAction::CONNECTION_DROP:
@@ -750,7 +758,10 @@ std::vector<std::string> validateEventTimeline(
         uint32_t x = 0, y = 0;
         const std::string& s = e.targets.size() >= 2 ? e.targets[0] : e.from;
         const std::string& t = e.targets.size() >= 2 ? e.targets[1] : e.to;
-        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) dropped.insert(key(x, y));
+        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) {
+          dropped.insert(key(x, y));
+          unknownEdges.erase(key(x, y));
+        }
         break;
       }
       case EventAction::CONNECTION_RESTORE:
@@ -758,7 +769,10 @@ std::vector<std::string> validateEventTimeline(
         uint32_t x = 0, y = 0;
         const std::string& s = e.targets.size() >= 2 ? e.targets[0] : e.from;
         const std::string& t = e.targets.size() >= 2 ? e.targets[1] : e.to;
-        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) dropped.erase(key(x, y));
+        if (resolveId(nodes, s, x) && resolveId(nodes, t, y)) {
+          dropped.erase(key(x, y));
+          unknownEdges.erase(key(x, y));
+        }
         break;
       }
       case EventAction::PARTITION_NETWORK: {
@@ -770,10 +784,20 @@ std::vector<std::string> validateEventTimeline(
           for (size_t j = i + 1; j < groups.size(); ++j) {
             for (uint32_t x : groups[i])
               for (uint32_t y : groups[j])
-                if (declared.count(key(x, y))) partitionCut.insert(key(x, y));
+                if (declared.count(key(x, y))) {
+                  partitionCut.insert(key(x, y));
+                  unknownEdges.erase(key(x, y));  // this cut settles the edge
+                }
           }
         }
-        if (topologyWired && componentCount() != groups.size()) {
+        // componentCount() reads the whole graph, so it is only meaningful when
+        // every node's running state, every declared edge and the node set
+        // itself are known. An earlier unmodelled step leaves at least one of
+        // those open, and a component count guessed from it would fail a
+        // scenario that is merely not implemented yet.
+        const bool stateKnown = !unknownNodeSet && unknownNodes.empty() &&
+                                unknownEdges.empty();
+        if (topologyWired && stateKnown && componentCount() != groups.size()) {
           problems.push_back(
               "network_partition " + describe(e) + " requests " +
               std::to_string(groups.size()) +
@@ -787,8 +811,22 @@ std::vector<std::string> validateEventTimeline(
       case EventAction::HEAL_PARTITION:
         partitionCut.clear();
         break;
+      case EventAction::UNKNOWN:
+      case EventAction::ADD_NODES:
+      case EventAction::REMOVE_NODE:
+        // No lifecycle model exists for these. An UNKNOWN action is an
+        // arbitrary string -- it could start, stop or relink anything -- and
+        // add/remove change the node set. Treat every node and declared edge as
+        // unknown from here on rather than guessing, and keep walking so the
+        // remaining supported events are still checked against whatever the
+        // timeline settles afterwards.
+        unknownNodes = allNodes;
+        unknownEdges = declared;
+        unknownNodeSet = true;
+        break;
       case EventAction::INJECT_MESSAGE:
-        if (resolveId(nodes, e.from, a) && !running.count(a)) {
+        if (resolveId(nodes, e.from, a) && !unknownNodes.count(a) &&
+            !running.count(a)) {
           problems.push_back(
               "inject_message " + describe(e) + " sends from node '" + e.from +
               "', which is stopped at that point in the timeline; the runtime "

--- a/src/config/topology_planner.cpp
+++ b/src/config/topology_planner.cpp
@@ -705,6 +705,44 @@ std::vector<std::string> validateEventTimeline(
     }
     return comps;
   };
+  // Every node reachable from `src` over live edges. sendSingle() hands the
+  // destination to findRoute(), which walks the sender's own layout, so a
+  // destination outside the sender's live component has no route at all and
+  // the send is refused rather than merely delayed. (issue 62)
+  auto reachableFrom = [&](uint32_t src) {
+    std::set<uint32_t> seen{src};
+    std::vector<uint32_t> frontier{src};
+    while (!frontier.empty()) {
+      const uint32_t cur = frontier.back();
+      frontier.pop_back();
+      auto it = adj.find(cur);
+      if (it == adj.end()) continue;
+      for (uint32_t peer : it->second) {
+        if (seen.count(peer)) continue;
+        if (!edgeLive(cur, peer)) continue;
+        seen.insert(peer);
+        frontier.push_back(peer);
+      }
+    }
+    return seen;
+  };
+  // sendBroadcast() enqueues to the sender's direct connections and reports
+  // how many took the message; with none live it returns false. Reachability
+  // further out does not save it -- there is no first hop to hand it to.
+  auto hasLivePeer = [&](uint32_t src) {
+    auto it = adj.find(src);
+    if (it == adj.end()) return false;
+    return std::any_of(it->second.begin(), it->second.end(),
+                       [&](uint32_t peer) { return edgeLive(src, peer); });
+  };
+  // Whole-graph questions -- the component count, and reachability -- read
+  // every node's running state, every declared edge and the node set itself.
+  // An earlier unmodelled step leaves at least one of those open, and an
+  // answer guessed from it would fail a scenario that is merely not
+  // implemented yet.
+  auto stateKnown = [&]() {
+    return !unknownNodeSet && unknownNodes.empty() && unknownEdges.empty();
+  };
 
   // One or two ordered steps per event; a delayed restart is a stop now and a
   // start at time+delay, exactly as EventFactory schedules it.
@@ -790,14 +828,7 @@ std::vector<std::string> validateEventTimeline(
                 }
           }
         }
-        // componentCount() reads the whole graph, so it is only meaningful when
-        // every node's running state, every declared edge and the node set
-        // itself are known. An earlier unmodelled step leaves at least one of
-        // those open, and a component count guessed from it would fail a
-        // scenario that is merely not implemented yet.
-        const bool stateKnown = !unknownNodeSet && unknownNodes.empty() &&
-                                unknownEdges.empty();
-        if (topologyWired && stateKnown && componentCount() != groups.size()) {
+        if (topologyWired && stateKnown() && componentCount() != groups.size()) {
           problems.push_back(
               "network_partition " + describe(e) + " requests " +
               std::to_string(groups.size()) +
@@ -824,15 +855,45 @@ std::vector<std::string> validateEventTimeline(
         unknownEdges = declared;
         unknownNodeSet = true;
         break;
-      case EventAction::INJECT_MESSAGE:
-        if (resolveId(nodes, e.from, a) && !unknownNodes.count(a) &&
-            !running.count(a)) {
+      case EventAction::INJECT_MESSAGE: {
+        // EventFactory reads the sender from `from`, falling back to `target`;
+        // resolve it the same way or the two disagree about what is checked.
+        const std::string& sender = e.from.empty() ? e.target : e.from;
+        if (!resolveId(nodes, sender, a) || unknownNodes.count(a)) break;
+        if (!running.count(a)) {
           problems.push_back(
-              "inject_message " + describe(e) + " sends from node '" + e.from +
+              "inject_message " + describe(e) + " sends from node '" + sender +
               "', which is stopped at that point in the timeline; the runtime "
               "refuses the injection and fails the run");
+          break;  // the send never happens, so where it was aimed is moot
+        }
+        // A running sender is only half of it: the destination has to still be
+        // reachable through whatever earlier events left of the mesh, or the
+        // send is refused and MessageInjectEvent throws. (issue 62)
+        if (!topologyWired || !stateKnown()) break;
+        // EventFactory maps an absent `to`, "broadcast" and "all" to node 0.
+        if (e.to.empty() || e.to == "broadcast" || e.to == "all") {
+          if (!hasLivePeer(a)) {
+            problems.push_back(
+                "inject_message " + describe(e) + " broadcasts from node '" +
+                sender + "', which has no live peer at that point in the "
+                "timeline; the runtime refuses the broadcast and fails the run");
+          }
+          break;
+        }
+        uint32_t dest = 0;
+        // An unresolvable destination is already a config error of its own, and
+        // a self-addressed send is not a topology question.
+        if (!resolveId(nodes, e.to, dest) || dest == a) break;
+        if (!reachableFrom(a).count(dest)) {
+          problems.push_back(
+              "inject_message " + describe(e) + " sends to node '" + e.to +
+              "', which earlier events leave unreachable from '" + sender +
+              "' (a stopped node, a dropped link or an active partition lies "
+              "between them); the runtime finds no route and fails the run");
         }
         break;
+      }
       default:
         break;
     }

--- a/test/test_topology_planner.cpp
+++ b/test/test_topology_planner.cpp
@@ -629,9 +629,10 @@ TEST_CASE("validateEventTimeline rejects sequences that must fail at runtime",
     REQUIRE(problems.empty());
   }
 
-  SECTION("an unmodelled action skips the check rather than guess") {
-    // start_all_nodes parses as UNKNOWN; the walker cannot track it, so it must
-    // not flag a false positive (the unknown action fails validation on its own).
+  SECTION("an unmodelled action suspends the checks that depend on it") {
+    // start_all_nodes parses as UNKNOWN; it could have restarted n2, so the
+    // component count the partition needs is no longer knowable and must not
+    // be guessed at (the unknown action fails validation on its own).
     EventConfig unknown; unknown.time = 6; unknown.action = EventAction::UNKNOWN;
     unknown.action_raw = "start_all_nodes";
     EventConfig part; part.time = 10; part.action = EventAction::PARTITION_NETWORK;
@@ -639,5 +640,62 @@ TEST_CASE("validateEventTimeline rejects sequences that must fail at runtime",
     const auto problems =
         validateEventTimeline({stopEvent(5, "n2"), unknown, part}, line, nodes);
     REQUIRE(problems.empty());
+  }
+
+  SECTION("a broken step before an unmodelled action is still reported") {
+    // The walker used to scan the whole list up front and return on any
+    // unmodelled action, discarding even the steps that ran before it with
+    // fully known state. Those are deterministic failures and must survive.
+    // (issue 63)
+    EventConfig inj; inj.time = 10; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    EventConfig unknown; unknown.time = 100; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    const auto problems =
+        validateEventTimeline({stopEvent(5, "n1"), inj, unknown}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
+  }
+
+  SECTION("an explicit event after an unmodelled one makes its target known again") {
+    // start_all_nodes leaves every node's running state unknown, but the later
+    // stop_node names n1 outright, so the injection after it is once again a
+    // certain failure.
+    EventConfig unknown; unknown.time = 5; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    EventConfig inj; inj.time = 20; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems =
+        validateEventTimeline({unknown, stopEvent(10, "n1"), inj}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
+  }
+
+  SECTION("an unmodelled action clears a stop the walker had recorded") {
+    // The mirror image: start_all_nodes may have brought n1 back, so the walker
+    // must not claim the later injection fails.
+    EventConfig unknown; unknown.time = 10; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    EventConfig inj; inj.time = 20; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems =
+        validateEventTimeline({stopEvent(5, "n1"), unknown, inj}, line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("add_nodes suspends the component count but not the injection check") {
+    // add_nodes changes the node set out from under componentCount(), so the
+    // partition -- which a prior stop_node would otherwise break -- is not
+    // judged. An injection from a node an explicit stop_node named afterwards
+    // still is, so exactly one problem comes back rather than none or two.
+    EventConfig add; add.time = 10; add.action = EventAction::ADD_NODES;
+    EventConfig part; part.time = 30; part.action = EventAction::PARTITION_NETWORK;
+    part.groups = {{"n1", "n2"}, {"n3"}};  // n2 is down: 3 components, not 2
+    EventConfig inj; inj.time = 40; inj.action = EventAction::INJECT_MESSAGE;
+    inj.from = "n1"; inj.to = "n3";
+    const auto problems = validateEventTimeline(
+        {stopEvent(5, "n2"), add, part, stopEvent(35, "n1"), inj}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
   }
 }

--- a/test/test_topology_planner.cpp
+++ b/test/test_topology_planner.cpp
@@ -699,3 +699,145 @@ TEST_CASE("validateEventTimeline rejects sequences that must fail at runtime",
     REQUIRE(problems[0].find("inject_message") != std::string::npos);
   }
 }
+
+TEST_CASE("validateEventTimeline checks injection reachability, not just the sender",
+          "[topology_planner][timeline]") {
+  // A running sender is only half of what the runtime needs. sendSingle() asks
+  // findRoute() for a connection whose subtree holds the destination and
+  // sendBroadcast() counts the peers it managed to enqueue to; either returning
+  // false makes MessageInjectEvent throw, so the run exits 1. Earlier topology
+  // events are what take those routes away. (issue 62)
+  const auto nodes = makeNodes(3);  // n1=1001, n2=1002, n3=1003
+  const std::vector<PlannedLink> line{{1001, 1002}, {1002, 1003}};
+
+  auto injectEvent = [](uint32_t t, const std::string& from, const std::string& to) {
+    EventConfig e; e.time = t; e.action = EventAction::INJECT_MESSAGE;
+    e.from = from; e.to = to;
+    return e;
+  };
+  auto dropEvent = [](uint32_t t, const std::string& a, const std::string& b) {
+    EventConfig e; e.time = t; e.action = EventAction::CONNECTION_DROP;
+    e.from = a; e.to = b;
+    return e;
+  };
+
+  SECTION("a destination cut off by an earlier connection_drop") {
+    // The issue's own case: drop B-C on a line A-B-C, then send A -> C.
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n2", "n3"), injectEvent(10, "n1", "n3")}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("inject_message") != std::string::npos);
+    REQUIRE(problems[0].find("unreachable") != std::string::npos);
+  }
+
+  SECTION("a destination the same drop still leaves reachable") {
+    // n1 -> n2 survives the n2-n3 drop; only the far side is cut off.
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n2", "n3"), injectEvent(10, "n1", "n2")}, line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("a connection_restore before the injection puts the route back") {
+    EventConfig restore; restore.time = 8;
+    restore.action = EventAction::CONNECTION_RESTORE;
+    restore.from = "n2"; restore.to = "n3";
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n2", "n3"), restore, injectEvent(10, "n1", "n3")},
+        line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("a destination stranded by a stopped relay") {
+    // n2 is the only path between n1 and n3, so stopping it strands n3 even
+    // though both endpoints of the injection are running.
+    EventConfig stop; stop.time = 5; stop.action = EventAction::STOP_NODE;
+    stop.target = "n2";
+    const auto problems =
+        validateEventTimeline({stop, injectEvent(10, "n1", "n3")}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("unreachable") != std::string::npos);
+  }
+
+  SECTION("a destination on the far side of an active partition") {
+    EventConfig part; part.time = 10; part.action = EventAction::PARTITION_NETWORK;
+    part.groups = {{"n1", "n2"}, {"n3"}};
+    const auto problems =
+        validateEventTimeline({part, injectEvent(20, "n1", "n3")}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("unreachable") != std::string::npos);
+  }
+
+  SECTION("the same partition healed before the injection") {
+    EventConfig part; part.time = 10; part.action = EventAction::PARTITION_NETWORK;
+    part.groups = {{"n1", "n2"}, {"n3"}};
+    EventConfig heal; heal.time = 20; heal.action = EventAction::HEAL_PARTITION;
+    const auto problems = validateEventTimeline(
+        {part, heal, injectEvent(20, "n1", "n3")}, line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("a broadcast from a sender left with no live peer") {
+    // sendBroadcast() enqueues to direct connections only and returns false
+    // when it reaches none, so a sender with every incident link down fails
+    // even though the rest of the mesh is intact.
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n1", "n2"), injectEvent(10, "n1", "")}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("no live peer") != std::string::npos);
+  }
+
+  SECTION("a broadcast spelled 'broadcast' is the same check") {
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n1", "n2"), injectEvent(10, "n1", "broadcast")},
+        line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("no live peer") != std::string::npos);
+  }
+
+  SECTION("a broadcast from a sender that still has one peer is fine") {
+    // n2 keeps n1 as a peer after the n2-n3 drop; a broadcast only needs one.
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n2", "n3"), injectEvent(10, "n2", "broadcast")},
+        line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("a stopped sender is reported once, not twice") {
+    // The sender being down already refuses the injection; adding a second
+    // problem for the destination it therefore cannot reach is noise.
+    EventConfig stop; stop.time = 5; stop.action = EventAction::STOP_NODE;
+    stop.target = "n1";
+    const auto problems =
+        validateEventTimeline({stop, injectEvent(10, "n1", "n3")}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("is stopped at that point") != std::string::npos);
+  }
+
+  SECTION("the sender spelled as 'target', the way EventFactory accepts it") {
+    EventConfig inj; inj.time = 10; inj.action = EventAction::INJECT_MESSAGE;
+    inj.target = "n1"; inj.to = "n3";  // `target` is EventFactory's sender alias
+    const auto problems =
+        validateEventTimeline({dropEvent(5, "n2", "n3"), inj}, line, nodes);
+    REQUIRE(problems.size() == 1);
+    REQUIRE(problems[0].find("unreachable") != std::string::npos);
+  }
+
+  SECTION("an unmodelled action suspends the reachability check") {
+    // start_all_nodes could relink anything, so the walker must not claim the
+    // destination is unreachable -- the same rule the component count follows.
+    EventConfig unknown; unknown.time = 7; unknown.action = EventAction::UNKNOWN;
+    unknown.action_raw = "start_all_nodes";
+    const auto problems = validateEventTimeline(
+        {dropEvent(5, "n2", "n3"), unknown, injectEvent(10, "n1", "n3")},
+        line, nodes);
+    REQUIRE(problems.empty());
+  }
+
+  SECTION("an unwired topology is not judged") {
+    // With no planned links there is no adjacency to reason over; every
+    // destination would look unreachable.
+    const auto problems =
+        validateEventTimeline({injectEvent(10, "n1", "n3")}, {}, nodes);
+    REQUIRE(problems.empty());
+  }
+}


### PR DESCRIPTION
Closes #62.

Follow-up from the PR #59 review (open P2 thread on `src/config/topology_planner.cpp:795`, deferred per the severity floor in `AGENTS.md`).

## The defect

`validateEventTimeline()` approved an `inject_message` as soon as its **sender** was still running. The runtime needs more than that:

- `sendSingle()` → `router::send()` → `findRoute()` looks for a connection whose subtree holds the destination and returns `false` when there is none;
- `sendBroadcast()` → `router::broadcast()` enqueues to the sender's direct connections and returns `false` (`success > 0`) when it reaches none.

Either `false` makes `VirtualNode::injectMessage()` return `false`, which `MessageInjectEvent::execute()` turns into a `throw`. So the issue's case — a `connection_drop` of `B-C` on a line `A-B-C`, then an injection `A → C` — passed `--validate-only` and then deterministically exited 1 on the ordinary run.

## The fix

The walker already tracks the wired adjacency, dropped links, active partition cuts and each node's running state. It now uses them at the injection step:

- **unicast** — the destination must sit in the sender's live component, a BFS over the same `edgeLive()` predicate `componentCount()` already uses. A stopped relay, a dropped link or an unhealed partition between the two is reported.
- **broadcast** (absent `to`, `"broadcast"`, `"all"` — exactly what `EventFactory` maps to node 0) — the sender needs one live incident edge. Reachability further out cannot save it; there is no first hop.

Both are whole-graph questions, so both are gated on the same *state is known* condition the component count uses: after an unmodelled action (`UNKNOWN`, `add_nodes`, `remove_node`) nothing is judged rather than guessed. A stopped sender is still reported once and the destination check skipped — the send never happens, so where it was aimed is moot. A self-addressed send and an unresolvable destination are left alone; neither is a topology question.

The sender is now resolved the way `EventFactory` resolves it (`from`, falling back to `target`), so validation and runtime agree on which node is sending. Spelling the sender as `target` previously skipped every injection check.

## The one shipped scenario this rejects

`examples/scenarios/issue_138_message_routing.yaml` phase 4 injects `node-1 → node-6` while the partition is up, annotated *"should fail/drop"*. `inject_message` has no "expected to be refused" form — the run aborted at t=60, and phases 5 and 6, the ones that actually test issue 138's post-heal routing, never ran. `ci_integration_check.sh` never caught it because it only `--validate-only`s shipped scenarios.

The two probes are removed with a note in their place. `partition_delivery_test.yaml` already measures partition isolation by comparing delivery counts against a control run — a form the runtime can express. Docs in `ISSUE_138_SCENARIOS.md` updated to match.

The other three scenarios that inject (`heal_then_inject_test`, `partition_delivery_test`, `star_topology`) are unaffected: each injects into a healed or intact mesh.

## Tests

Twelve new sections in `test/test_topology_planner.cpp`: the issue's drop case, a destination the same drop leaves reachable, a `connection_restore` that puts the route back, a stranded relay, an active partition and its heal, broadcast with and without a live peer, both broadcast spellings, single-report for a stopped sender, the `target` sender alias, suspension after an unmodelled action, and an unwired topology.

## Notes for the reviewer

- **Stacked on #65** (`feature/timeline-validation-unknown-action-63`), which is unmerged and rewrites this same `INJECT_MESSAGE` case. Basing on `feat/v2-release-readiness-58` directly would have produced a merge conflict whose resolution has to re-derive the unknown-state guard by hand — the class of thing that goes wrong silently. Once #65 merges this diff shrinks to its own commit. Review just [`eec1209`](https://github.com/Alteriom/painlessMesh-simulator/commit/eec1209) or `git diff origin/feature/timeline-validation-unknown-action-63..origin/feature/inject-reachability-62`.
- The agent container has no C++ toolchain, so **CI is the verification** for this change — it was not compiled locally.